### PR TITLE
fix: use configured socket URL for client connections

### DIFF
--- a/src/app/room/[id]/page.tsx
+++ b/src/app/room/[id]/page.tsx
@@ -36,14 +36,14 @@ export default function RoomPage() {
 			setError('Name is required')
 			return
 		}
-		const socket_url =
-			process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3000'
-		const newSocket = io({
-			path: '/socket.io',
-			transports: ['websocket', 'polling'],
-			reconnectionAttempts: 5,
-			reconnectionDelay: 1000,
-			timeout: 10000,
+                const socket_url =
+                        process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3000'
+                const newSocket = io(socket_url, {
+                        path: '/socket.io',
+                        transports: ['websocket', 'polling'],
+                        reconnectionAttempts: 5,
+                        reconnectionDelay: 1000,
+                        timeout: 10000,
 			autoConnect: true,
 			forceNew: true,
 		})

--- a/src/lib/socket-client.ts
+++ b/src/lib/socket-client.ts
@@ -1,17 +1,20 @@
 import { io, Socket } from 'socket.io-client';
 import { ClientToServerEvents, ServerToClientEvents } from '../server/socket';
 
+const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3000';
 
-
-export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io({
-  path: '/socket.io',
-  transports: ['websocket', 'polling'],
-  reconnectionDelay: 1000,
-  reconnectionDelayMax: 5000,
-  reconnectionAttempts: 5,
-  autoConnect: true,
-  withCredentials: true,
-});
+export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
+  SOCKET_URL,
+  {
+    path: '/socket.io',
+    transports: ['websocket', 'polling'],
+    reconnectionDelay: 1000,
+    reconnectionDelayMax: 5000,
+    reconnectionAttempts: 5,
+    autoConnect: true,
+    withCredentials: true,
+  }
+);
 
 socket.on('connect_error', (error) => {
   console.error('Socket connection error:', error);


### PR DESCRIPTION
## Summary
- respect `NEXT_PUBLIC_SOCKET_URL` when creating Socket.IO client
- centralize socket URL configuration in shared client helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Config (unnamed): Key "extends": This appears to be in eslintrc format rather than flat config format)*
- `npm run build` *(fails: Failed to fetch font `Roboto Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_6896060d3884832081251e479a3ee19c