### PR TITLE
Add connection status store and improve room page

### DIFF
--- a/src/store/socket.ts
+++ b/src/store/socket.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
+
+interface SocketStore {
+  status: ConnectionStatus;
+  setStatus: (status: ConnectionStatus) => void;
+}
+
+export const useSocketStore = create<SocketStore>((set) => ({
+  status: 'disconnected',
+  setStatus: (status) => set({ status }),
+}));


### PR DESCRIPTION
## Summary
- memoize room actions and derived values with `useCallback`/`useMemo`
- show retry banner on socket connection errors
- share socket connection status via new Zustand store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(Config (unnamed): Key "extends": This appears to be in eslintrc format rather than flat config format.)*

------
https://chatgpt.com/codex/tasks/task_e_689607b019208320905ab89a2eae8a0b