### PR TITLE
feat: add custom deck presets and results export

### DIFF
--- a/src/app/room/[id]/components/AdminControls.tsx
+++ b/src/app/room/[id]/components/AdminControls.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react'
 import { Room } from '@/types/room'
+import { usePresetsStore } from '@/store/presets'
+import { useRoomStore } from '@/store/room'
 
 interface AdminControlsProps {
   room: Room
@@ -20,6 +22,10 @@ export default function AdminControls({
 }: AdminControlsProps) {
   const [showTimerSettings, setShowTimerSettings] = useState(false)
   const [timerDuration, setTimerDuration] = useState(room.timerDuration)
+  const { customDeck, setCustomDeck, timerPresets, setTimerPresets } = usePresetsStore()
+  const setVotingOptions = useRoomStore((state) => state.setVotingOptions)
+  const [deckInput, setDeckInput] = useState(customDeck.join(','))
+  const [timerPresetsInput, setTimerPresetsInput] = useState(timerPresets.join(','))
 
   const handleToggleRoomEnabled = () => {
     onToggleRoomEnabled(!room.enabled)
@@ -35,6 +41,27 @@ export default function AdminControls({
   const handleSetTimer = () => {
     onSetTimer(timerDuration)
     setShowTimerSettings(false)
+  }
+
+  const handleSaveDeck = () => {
+    const values = deckInput
+      .split(',')
+      .map((v) => parseInt(v.trim()))
+      .filter((v) => !isNaN(v))
+    if (values.length) {
+      setCustomDeck(values)
+      setVotingOptions(values)
+    }
+  }
+
+  const handleSaveTimerPresets = () => {
+    const presets = timerPresetsInput
+      .split(',')
+      .map((v) => parseInt(v.trim()))
+      .filter((v) => !isNaN(v))
+    if (presets.length) {
+      setTimerPresets(presets)
+    }
   }
 
   if (!isOpen) return null
@@ -115,6 +142,48 @@ export default function AdminControls({
               </div>
             </div>
           )}
+
+          {/* Custom Deck Input */}
+          <div className="flex flex-col gap-2">
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              Deck Values (comma separated)
+            </span>
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={deckInput}
+                onChange={(e) => setDeckInput(e.target.value)}
+                className="flex-1 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-md text-sm"
+              />
+              <button
+                onClick={handleSaveDeck}
+                className="px-3 py-1 bg-[#00A550] text-white rounded-md text-sm"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+
+          {/* Timer Presets Input */}
+          <div className="flex flex-col gap-2">
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              Timer Presets (seconds, comma separated)
+            </span>
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={timerPresetsInput}
+                onChange={(e) => setTimerPresetsInput(e.target.value)}
+                className="flex-1 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-md text-sm"
+              />
+              <button
+                onClick={handleSaveTimerPresets}
+                className="px-3 py-1 bg-[#00A550] text-white rounded-md text-sm"
+              >
+                Save
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/room/[id]/components/ResultsExport.tsx
+++ b/src/app/room/[id]/components/ResultsExport.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { User } from '@/types/room'
+
+interface ResultsExportProps {
+  users: User[]
+}
+
+export default function ResultsExport({ users }: ResultsExportProps) {
+  const exportJSON = () => {
+    const data = users.map((u) => ({ name: u.name, vote: u.vote }))
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'results.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const exportCSV = () => {
+    const header = 'name,vote\n'
+    const rows = users
+      .map((u) => `${u.name},${u.vote ?? ''}`)
+      .join('\n')
+    const blob = new Blob([header + rows], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'results.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  if (!users.length) return null
+
+  return (
+    <div className="flex gap-2 justify-end mt-4">
+      <button
+        onClick={exportCSV}
+        className="px-3 py-1 bg-[#00A550] text-white rounded-md text-sm"
+      >
+        CSV
+      </button>
+      <button
+        onClick={exportJSON}
+        className="px-3 py-1 bg-[#00A550] text-white rounded-md text-sm"
+      >
+        JSON
+      </button>
+    </div>
+  )
+}

--- a/src/app/room/[id]/components/VotingResults.tsx
+++ b/src/app/room/[id]/components/VotingResults.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { User } from '@/types/room'
+import ResultsExport from './ResultsExport'
 
 interface VotingResultsProps {
 	users: User[]
@@ -80,12 +81,12 @@ export default function VotingResults({ users, revealed }: VotingResultsProps) {
 				</div>
 
 				{/* Individual Votes List */}
-				<div>
-					<h4 className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
-						Individual Votes
-					</h4>
-					<div className='max-h-40 overflow-y-auto space-y-1 pr-2'>
-						{' '}
+                                <div>
+                                        <h4 className='text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
+                                                Individual Votes
+                                        </h4>
+                                        <div className='max-h-40 overflow-y-auto space-y-1 pr-2'>
+                                                {' '}
 						{/* Scrollable container */}
 						{votingEstimators
 							.sort((a, b) => a.name.localeCompare(b.name)) // Sort alphabetically
@@ -98,9 +99,10 @@ export default function VotingResults({ users, revealed }: VotingResultsProps) {
 									<span className='font-medium'>{user.vote}</span>
 								</div>
 							))}
-					</div>
-				</div>
-			</div>
-		</div>
-	)
+                                        </div>
+                                </div>
+                                <ResultsExport users={votingEstimators} />
+                        </div>
+                </div>
+        )
 }

--- a/src/store/presets.ts
+++ b/src/store/presets.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import { FIBONACCI_SEQUENCE, DEFAULT_TIMER_DURATION } from '@/types/room';
+
+interface PresetsState {
+  customDeck: number[];
+  timerPresets: number[];
+  setCustomDeck: (deck: number[]) => void;
+  setTimerPresets: (presets: number[]) => void;
+  addTimerPreset: (duration: number) => void;
+  removeTimerPreset: (duration: number) => void;
+}
+
+const DEFAULT_TIMER_PRESETS = [DEFAULT_TIMER_DURATION, 30, 60];
+
+export const usePresetsStore = create<PresetsState>((set) => ({
+  customDeck: FIBONACCI_SEQUENCE,
+  timerPresets: DEFAULT_TIMER_PRESETS,
+  setCustomDeck: (deck) => set({ customDeck: deck }),
+  setTimerPresets: (presets) => set({ timerPresets: presets }),
+  addTimerPreset: (duration) =>
+    set((state) => ({
+      timerPresets: state.timerPresets.includes(duration)
+        ? state.timerPresets
+        : [...state.timerPresets, duration].sort((a, b) => a - b),
+    })),
+  removeTimerPreset: (duration) =>
+    set((state) => ({
+      timerPresets: state.timerPresets.filter((t) => t !== duration),
+    })),
+}));

--- a/src/store/room.ts
+++ b/src/store/room.ts
@@ -13,6 +13,7 @@ interface RoomStore extends RoomState {
   updateTimer: (duration: number) => void;
   toggleRoomEnabled: (enabled: boolean) => void;
   setRoomTimer: (duration: number) => void;
+  setVotingOptions: (options: number[]) => void;
 }
 
 const initialState: RoomState = {
@@ -73,5 +74,6 @@ export const useRoomStore = create<RoomStore>((set) => ({
     })),
   updateTimer: (duration) => set({ timerDuration: duration }),
   toggleRoomEnabled: (enabled) => set({ enabled }),
-  setRoomTimer: (duration) => set({ timerDuration: duration })
+  setRoomTimer: (duration) => set({ timerDuration: duration }),
+  setVotingOptions: (options) => set({ votingOptions: options })
 }));


### PR DESCRIPTION
## Summary
- add zustand store for custom decks and timer presets
- extend admin controls with inputs to update decks and timer presets
- enable exporting revealed votes as CSV or JSON

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689607b23ee88320b2fcfecd4d998887