### PR TITLE
Respect configured socket URL in room page

### DIFF
--- a/src/app/room/[id]/page.tsx
+++ b/src/app/room/[id]/page.tsx
@@ -36,17 +36,21 @@ export default function RoomPage() {
 			setError('Name is required')
 			return
 		}
-		const socket_url =
-			process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3000'
-		const newSocket = io({
-			path: '/socket.io',
-			transports: ['websocket', 'polling'],
-			reconnectionAttempts: 5,
-			reconnectionDelay: 1000,
-			timeout: 10000,
-			autoConnect: true,
-			forceNew: true,
-		})
+                const socket_url =
+                        process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3000'
+                if (!socket_url) {
+                        setError('Socket server URL is not defined')
+                        return
+                }
+                const newSocket = io(socket_url, {
+                        path: '/socket.io',
+                        transports: ['websocket', 'polling'],
+                        reconnectionAttempts: 5,
+                        reconnectionDelay: 1000,
+                        timeout: 10000,
+                        autoConnect: true,
+                        forceNew: true,
+                })
 		setSocket(newSocket)
 
 		const role = searchParams?.get('role') || 'estimator'


### PR DESCRIPTION
## Summary
- Pass `NEXT_PUBLIC_SOCKET_URL` to the socket.io client when connecting to a room
- Guard against missing socket URL before initializing socket

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Config (unnamed): Key "extends": This appears to be in eslintrc format rather than flat config format.)*

------
https://chatgpt.com/codex/tasks/task_e_6896074741ec8320814ade365d09fd58