### PR TITLE
docs: fix duplicate phrasing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ To start the development server:
 npm run dev:server
 ```
 
-The application will be available at available at `http://localhost:3000`
+The application will be available at `http://localhost:3000`
 
-## Build of Production
+## Build for Production
 
 ```bash
 npm run build


### PR DESCRIPTION
## Summary
- clarify development instructions by removing a duplicated phrase
- correct heading to "Build for Production" for consistency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Config (unnamed): Key "extends": This appears to be in eslintrc format rather than flat config format.)*


------
https://chatgpt.com/codex/tasks/task_e_6896073f1e288320b656787723d9527b